### PR TITLE
feat: ArgoCD GitOps 배포를 위한 k8s 매니페스트 추가

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+  namespace: opentraum
+  labels:
+    app: user-service
+    app.kubernetes.io/part-of: opentraum
+    app.kubernetes.io/component: user
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service
+  template:
+    metadata:
+      labels:
+        app: user-service
+        app.kubernetes.io/part-of: opentraum
+        app.kubernetes.io/component: user
+    spec:
+      imagePullSecrets:
+        - name: harbor-secret
+      containers:
+        - name: user-service
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:latest
+          ports:
+            - containerPort: 8082
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: opentraum-config
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://opentraum-postgres:5432/opentraum_user"
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      restartPolicy: Always

--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  namespace: opentraum
+  labels:
+    app: user-service
+    app.kubernetes.io/part-of: opentraum
+spec:
+  selector:
+    app: user-service
+  ports:
+    - port: 8082
+      targetPort: 8082
+  type: ClusterIP


### PR DESCRIPTION
## 개요
ArgoCD App of Apps 패턴 기반 GitOps 배포를 위해 k8s 매니페스트를 추가합니다.

## 변경 사항
- `k8s/deployment.yml` 추가
  - Harbor 레지스트리 이미지 사용
  - imagePullSecrets 설정 (harbor-secret)
  - livenessProbe / readinessProbe 설정
- `k8s/service.yml` 추가
  - ClusterIP 타입

## 배포 구조
- ArgoCD `opentraum-user-service` Application이 해당 레포 k8s/ 경로를 감시
- main 브랜치 변경 시 EKS opentraum 네임스페이스에 자동 배포

## 이미지
- `amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:latest`

## 체크리스트
- [x] deployment.yml 작성
- [x] service.yml 작성
- [ ] ArgoCD Deploy Key 등록
- [ ] ArgoCD Application 생성
- [ ] ArgoCD Sync 확인

## 관련 이슈
Closes #8 