### PR TITLE
feat: PostgreSQL → MariaDB 전환

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.gradle/
+build/
+.git/
+.github/
+*.md
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /app
+
+COPY gradle/ gradle/
+COPY gradlew .
+COPY build.gradle settings.gradle ./
+
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+COPY src/ src/
+
+RUN ./gradlew bootJar --no-daemon -x test
+
 FROM eclipse-temurin:21-jre-alpine AS runtime
 
 WORKDIR /app
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-COPY build/libs/opentraum-user-service-*.jar app.jar
+COPY --from=builder /app/build/libs/*.jar app.jar
 
 RUN chown -R appuser:appgroup /app
 
@@ -12,4 +26,8 @@ USER appuser
 
 EXPOSE 8082
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ dependencies {
     // Spring WebFlux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    // R2DBC + PostgreSQL
+    // R2DBC + MariaDB
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
-    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+    runtimeOnly 'io.asyncer:r2dbc-mysql:1.1.0'
 
     // Redis Reactive
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -41,6 +41,8 @@ spec:
               value: "opentraum"
             - name: DB_PASSWORD
               value: "opentraum"
+            - name: SPRING_R2DBC_URL
+              value: "r2dbc:postgresql://opentraum-postgres:5432/opentraum_user"
           resources:
             requests:
               memory: "128Mi"

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -25,7 +25,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: user-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:37815e9b370b412ab220f7e9bdf32bd684385909
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:ffdd4208d8c9870d9ec31730d847e7cc5712af0b
           ports:
             - containerPort: 8082
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -23,7 +23,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: user-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:f5a959960b3a01f9c937767386fd66270e687aea
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:ff1af38ab63d081dbd142293da5f949076bea192
           ports:
             - containerPort: 8082
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -31,8 +31,16 @@ spec:
             - configMapRef:
                 name: opentraum-config
           env:
-            - name: SPRING_DATASOURCE_URL
-              value: "jdbc:postgresql://opentraum-postgres:5432/opentraum_user"
+            - name: DB_HOST
+              value: "opentraum-postgres"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "opentraum_user"
+            - name: DB_USERNAME
+              value: "opentraum"
+            - name: DB_PASSWORD
+              value: "opentraum"
           resources:
             requests:
               memory: "128Mi"

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -23,7 +23,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: user-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:latest
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:f5a959960b3a01f9c937767386fd66270e687aea
           ports:
             - containerPort: 8082
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: user
 spec:
+  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -25,7 +25,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: user-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:ff1af38ab63d081dbd142293da5f949076bea192
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:37815e9b370b412ab220f7e9bdf32bd684385909
           ports:
             - containerPort: 8082
               protocol: TCP

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: user
     spec:
+      terminationGracePeriodSeconds: 10
       imagePullSecrets:
         - name: harbor-secret
       containers:
@@ -44,27 +45,37 @@ spec:
               value: "opentraum"
             - name: SPRING_R2DBC_URL
               value: "r2dbc:postgresql://opentraum-postgres:5432/opentraum_user"
+            - name: JAVA_OPTS
+              value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+            - name: SPRING_MAIN_LAZY_INITIALIZATION
+              value: "true"
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "250m"
-            limits:
               memory: "256Mi"
               cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 3
+            failureThreshold: 20
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8082
-            initialDelaySeconds: 60
-            periodSeconds: 15
-            timeoutSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8082
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
       restartPolicy: Always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     name: opentraum-user-service
 
   r2dbc:
-    url: r2dbc:postgresql://localhost:5432/opentraum_user
-    username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:postgres}
+    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_user}
+    username: ${DB_USERNAME:opentraum}
+    password: ${DB_PASSWORD:opentraum123!}
 
   data:
     redis:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,26 +1,26 @@
 CREATE TABLE IF NOT EXISTS tenants (
-    id          BIGSERIAL       PRIMARY KEY,
+    id          BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name        VARCHAR(255)    NOT NULL,
     slug        VARCHAR(100)    NOT NULL UNIQUE,
     domain      VARCHAR(255),
     plan        VARCHAR(50)     NOT NULL DEFAULT 'FREE',
     is_active   BOOLEAN         NOT NULL DEFAULT TRUE,
-    created_at  TIMESTAMP       NOT NULL DEFAULT NOW()
+    created_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
+    INDEX idx_tenants_slug (slug),
+    INDEX idx_tenants_domain (domain)
 );
 
 CREATE TABLE IF NOT EXISTS users (
-    id          BIGSERIAL       PRIMARY KEY,
+    id          BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     email       VARCHAR(255)    NOT NULL UNIQUE,
     password    VARCHAR(255)    NOT NULL,
     name        VARCHAR(100)    NOT NULL,
     phone       VARCHAR(20),
     role        VARCHAR(50)     NOT NULL DEFAULT 'USER',
-    tenant_id   BIGINT          NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    tenant_id   BIGINT          NOT NULL,
     created_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMP       NOT NULL DEFAULT NOW()
+    updated_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
+    INDEX idx_users_email (email),
+    INDEX idx_users_tenant_id (tenant_id),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
 );
-
-CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-CREATE INDEX IF NOT EXISTS idx_users_tenant_id ON users(tenant_id);
-CREATE INDEX IF NOT EXISTS idx_tenants_slug ON tenants(slug);
-CREATE INDEX IF NOT EXISTS idx_tenants_domain ON tenants(domain);


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 드라이버 전환
- SKALA 미니프로젝트 1+2 (대량 요청 처리 + CDC) 대비

## Changes
- `r2dbc-postgresql` → `io.asyncer:r2dbc-mysql:1.1.0`
- connection string → `r2dbc:mariadb://opentraum-mariadb:3306`
- schema.sql MariaDB 호환 문법 전환

## Test plan
- [x] MariaDB Pod Running 확인
- [x] 서비스 Pod Running 확인 (새 이미지)
- [ ] /actuator/health 200 응답 확인
- [ ] CRUD API 정상 동작 확인