### PR TITLE
fix: K8s deployment.yml 클러스터 상태 동기화

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: user
 spec:
-  revisionHistoryLimit: 2
   replicas: 1
   selector:
     matchLabels:
@@ -23,9 +22,11 @@ spec:
       terminationGracePeriodSeconds: 10
       imagePullSecrets:
         - name: harbor-secret
+      priorityClassName: opentraum-medium
       containers:
         - name: user-service
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:ffdd4208d8c9870d9ec31730d847e7cc5712af0b
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-user-service:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8082
               protocol: TCP
@@ -34,28 +35,28 @@ spec:
                 name: opentraum-config
           env:
             - name: DB_HOST
-              value: "opentraum-postgres"
+              value: "opentraum-mariadb.mariadb"
             - name: DB_PORT
-              value: "5432"
+              value: "3306"
             - name: DB_NAME
               value: "opentraum_user"
             - name: DB_USERNAME
               value: "opentraum"
             - name: DB_PASSWORD
-              value: "opentraum"
+              value: "opentraum123!"
             - name: SPRING_R2DBC_URL
-              value: "r2dbc:postgresql://opentraum-postgres:5432/opentraum_user"
+              value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_user"
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
               value: "true"
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "500m"
             limits:
               memory: "512Mi"
-              cpu: "1000m"
+              cpu: "500m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 연결 (r2dbc:mysql://opentraum-mariadb.mariadb)
- NS 분리 FQDN 반영 (mariadb, kafka, redis)
- QoS=Guaranteed, PriorityClass, startupProbe 추가