### PR TITLE
feat: k8s 매니페스트 운영 설정 반영

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,10 +5,17 @@ metadata:
   namespace: opentraum
   labels:
     app: user-service
+    app.kubernetes.io/name: user-service
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: user
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: user-service
@@ -16,10 +23,18 @@ spec:
     metadata:
       labels:
         app: user-service
+        app.kubernetes.io/name: user-service
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: user
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 40
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: user-service
       imagePullSecrets:
         - name: harbor-secret
       priorityClassName: opentraum-medium
@@ -41,22 +56,28 @@ spec:
             - name: DB_NAME
               value: "opentraum_user"
             - name: DB_USERNAME
-              value: "opentraum"
+              valueFrom:
+                secretKeyRef:
+                  name: user-db-secret
+                  key: username
             - name: DB_PASSWORD
-              value: "opentraum123!"
+              valueFrom:
+                secretKeyRef:
+                  name: user-db-secret
+                  key: password
             - name: SPRING_R2DBC_URL
               value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_user"
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
-              value: "true"
+              value: "false"
           resources:
             requests:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "256Mi"
+              cpu: "250m"
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "1024Mi"
+              cpu: "1000m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary
- DB credentials 평문 → `user-db-secret` Secret 참조
- RollingUpdate 전략 + topologySpread 추가
- terminationGracePeriodSeconds 10 → 40
- SPRING_MAIN_LAZY_INITIALIZATION true → false
- resources requests 256Mi/250m, limits 1024Mi/1000m
- `revisionHistoryLimit: 2`, 라벨 `app.kubernetes.io/name` 추가

## Why
OpenTraum-Infra `k8s-manual/user-service/` 의 운영 설정을 본 레포 `k8s/` 로 이관해 ArgoCD GitOps 자동 배포 전환 준비를 완료합니다.

## Test plan
- [ ] `user-db-secret` 클러스터 배포 후 ArgoCD sync 정상 확인
- [ ] 새 Pod env 에 Secret 참조 정상 주입 확인
- [ ] user-service Pod replicas 다른 노드 스케줄 확인