### PR TITLE
chore: #26 Pod 자원 재산정

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -71,11 +71,11 @@ spec:
               value: "false"
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              memory: "512Mi"
+              cpu: "200m"
             limits:
-              memory: "1024Mi"
-              cpu: "1000m"
+              memory: "512Mi"
+              cpu: "200m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
Closes #26

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `250m` → `200m`
- `resources.requests.memory`: `256Mi` → `512Mi`
- `resources.limits.cpu`: `1000m` → `200m`
- `resources.limits.memory`: `1024Mi` → `512Mi`

## 영향
- QoS: `Burstable` → `Guaranteed` (가장 늦게 evict)
- CPU request 절감: -50m
- Memory request 증가: +256Mi (idle 보호)
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 1개 교체 (`maxSurge: 1`, `maxUnavailable: 0`)
