### PR TITLE
chore: CPU limit 정정 (200m → 350m)

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -72,10 +72,10 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "200m"
+              cpu: "350m"
             limits:
               memory: "512Mi"
-              cpu: "200m"
+              cpu: "350m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
Closes #28

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `200m` → `350m`
- `resources.limits.cpu`: `200m` → `350m`

## 영향

- 200m 환경 CrashLoopBackOff 해소 (startup probe 통과 보장)
- 350m 환경 실측 startup 46.06s, probe 한계 65s 대비 마진 +41%
- QoS Guaranteed 유지 (request = limit)
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 교체
